### PR TITLE
Make fit for Visual Studio 2017

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,6 @@ simple_example_static
 usbdmx_example
 usbdmx_example_static
 loopback_test
+
+# msvc project temporary files
+/tmp/

--- a/usbdmx.c
+++ b/usbdmx.c
@@ -27,6 +27,8 @@ ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 POSSIBILITY OF SUCH DAMAGE.
 */
 
+// make the usbdmx.h header automatically export the dll api functions
+#define USB_DMX_IMPLEMENTATION
 #include "usbdmx.h"
 #include "hidapi.h"
 #include <stdio.h>
@@ -112,7 +114,7 @@ void set_dev(int pos, char * serial) {
     memcpy(open_devices[pos].serial, serial, 16);
 }
 
-USB_DMX_DLL void GetAllConnectedInterfaces(TSERIALLIST* SerialList) {
+USB_DMX_DLL void USB_DMX_API_CALLING_CONVENTION GetAllConnectedInterfaces(TSERIALLIST* SerialList) {
     struct hid_device_info *devs, *cur_dev;
     int pos = 0;
 
@@ -133,7 +135,7 @@ USB_DMX_DLL void GetAllConnectedInterfaces(TSERIALLIST* SerialList) {
     hid_free_enumeration(devs);
 }
 
-USB_DMX_DLL DWORD GetDeviceVersion(TSERIAL Serial) {
+USB_DMX_DLL DWORD USB_DMX_API_CALLING_CONVENTION GetDeviceVersion(TSERIAL Serial) {
     struct hid_device_info *devs, *cur_dev;
     DWORD res = 0x100;
 
@@ -161,7 +163,7 @@ USB_DMX_DLL DWORD GetDeviceVersion(TSERIAL Serial) {
     return res;
 }
 
-USB_DMX_DLL void GetAllOpenedInterfaces(TSERIALLIST* SerialList) {
+USB_DMX_DLL void USB_DMX_API_CALLING_CONVENTION GetAllOpenedInterfaces(TSERIALLIST* SerialList) {
     int pos;
     int i;
     pos = 0;
@@ -175,7 +177,7 @@ USB_DMX_DLL void GetAllOpenedInterfaces(TSERIALLIST* SerialList) {
     wserial_to_serial(L"0000000000000000", SerialList[0][pos]);
 }
 
-USB_DMX_DLL DWORD SetInterfaceMode (TSERIAL Serial, unsigned char Mode) {
+USB_DMX_DLL DWORD USB_DMX_API_CALLING_CONVENTION SetInterfaceMode (TSERIAL Serial, unsigned char Mode) {
     int pos;
 
     pos = find_dev(Serial);
@@ -256,7 +258,7 @@ void *read_write_thread(void *pointer)
     return NULL;
 }
 
-USB_DMX_DLL DWORD OpenLink(TSERIAL Serial, TDMXArray *DMXOutArray, TDMXArray *DMXInArray) {
+USB_DMX_DLL DWORD USB_DMX_API_CALLING_CONVENTION OpenLink(TSERIAL Serial, TDMXArray *DMXOutArray, TDMXArray *DMXInArray) {
     hid_device *handle;
     int pos;
 
@@ -293,7 +295,7 @@ USB_DMX_DLL DWORD OpenLink(TSERIAL Serial, TDMXArray *DMXOutArray, TDMXArray *DM
     return 1;
 }
 
-USB_DMX_DLL DWORD CloseLink (TSERIAL Serial) {
+USB_DMX_DLL DWORD USB_DMX_API_CALLING_CONVENTION CloseLink (TSERIAL Serial) {
     int pos;
 
     pos = find_dev(Serial);
@@ -309,7 +311,7 @@ USB_DMX_DLL DWORD CloseLink (TSERIAL Serial) {
     return 1;
 }
 
-USB_DMX_DLL DWORD CloseAllLinks (void) {
+USB_DMX_DLL DWORD USB_DMX_API_CALLING_CONVENTION CloseAllLinks (void) {
     int i;
     int result = 1;
     for(i=0; i<MAX_OPENED; i++) {
@@ -322,27 +324,27 @@ USB_DMX_DLL DWORD CloseAllLinks (void) {
     return result;
 }
 
-USB_DMX_DLL DWORD RegisterInterfaceChangeNotification (THOSTDEVICECHANGEPROC Proc) {
+USB_DMX_DLL DWORD USB_DMX_API_CALLING_CONVENTION RegisterInterfaceChangeNotification (THOSTDEVICECHANGEPROC Proc) {
     // FIXME
     return 1;
 }
 
-USB_DMX_DLL DWORD UnregisterInterfaceChangeNotification (void) {
+USB_DMX_DLL DWORD USB_DMX_API_CALLING_CONVENTION UnregisterInterfaceChangeNotification (void) {
     // FIXME too
     return 1;
 }
 
-USB_DMX_DLL DWORD RegisterInputChangeNotification (THOSTDEVICECHANGEPROC Proc) {
+USB_DMX_DLL DWORD USB_DMX_API_CALLING_CONVENTION RegisterInputChangeNotification (THOSTDEVICECHANGEPROC Proc) {
     callback_func = Proc;
     return 1;
 }
 
-USB_DMX_DLL DWORD UnregisterInputChangeNotification (void) {
+USB_DMX_DLL DWORD USB_DMX_API_CALLING_CONVENTION UnregisterInputChangeNotification (void) {
     callback_func = NULL;
     return 1;
 }
 
-USB_DMX_DLL DWORD SetInterfaceAdvTxConfig(
+USB_DMX_DLL DWORD USB_DMX_API_CALLING_CONVENTION SetInterfaceAdvTxConfig(
     TSERIAL Serial, unsigned char Control, uint16_t Breaktime, uint16_t Marktime,
     uint16_t Interbytetime, uint16_t Interframetime, uint16_t Channelcount, uint16_t Startbyte
 ) {
@@ -384,7 +386,7 @@ USB_DMX_DLL DWORD SetInterfaceAdvTxConfig(
 
     return 1;
 }
-USB_DMX_DLL DWORD StoreInterfaceAdvTxConfig(TSERIAL Serial) {
+USB_DMX_DLL DWORD USB_DMX_API_CALLING_CONVENTION StoreInterfaceAdvTxConfig(TSERIAL Serial) {
     int pos;
     unsigned char buffer[35];
 
@@ -410,18 +412,18 @@ USB_DMX_DLL DWORD StoreInterfaceAdvTxConfig(TSERIAL Serial) {
 
     return 1;
 }
-USB_DMX_DLL DWORD RegisterInputChangeBlockNotification(THOSTINPUTCHANGEPROCBLOCK Proc) {
+USB_DMX_DLL DWORD USB_DMX_API_CALLING_CONVENTION RegisterInputChangeBlockNotification(THOSTINPUTCHANGEPROCBLOCK Proc) {
     callback_func_block = Proc;
     return 1;
 }
-USB_DMX_DLL DWORD UnregisterInputChangeBlockNotification(void) {
+USB_DMX_DLL DWORD USB_DMX_API_CALLING_CONVENTION UnregisterInputChangeBlockNotification(void) {
     callback_func_block = NULL;
     return 1;
 }
 
 /// And the Functions from usbdmxsi.USB_DMX_DLL also
 
-USB_DMX_DLL DWORD OpenInterface(TDMXArray *DMXOutArray, TDMXArray *DMXInArray, unsigned char Mode) {
+USB_DMX_DLL DWORD USB_DMX_API_CALLING_CONVENTION OpenInterface(TDMXArray *DMXOutArray, TDMXArray *DMXInArray, unsigned char Mode) {
     TSERIALLIST InterfaceList;
 
     GetAllOpenedInterfaces(&InterfaceList);
@@ -445,7 +447,7 @@ USB_DMX_DLL DWORD OpenInterface(TDMXArray *DMXOutArray, TDMXArray *DMXInArray, u
     return 1;
 }
 
-USB_DMX_DLL DWORD CloseInterface(void) {
+USB_DMX_DLL DWORD USB_DMX_API_CALLING_CONVENTION CloseInterface(void) {
     TSERIALLIST InterfaceList;
 
     GetAllOpenedInterfaces(&InterfaceList);

--- a/usbdmx.c
+++ b/usbdmx.c
@@ -33,8 +33,14 @@ POSSIBILITY OF SUCH DAMAGE.
 #include <sys/types.h>
 #include <string.h>
 #include <pthread.h>
-#include <unistd.h>
 #include <signal.h>
+
+#ifdef _MSC_VER
+#include <usleep.h>
+#else
+#include <unistd.h>
+#endif // _MSC_VER
+
 
 #define MAX_OPENED 32
 

--- a/usbdmx.h
+++ b/usbdmx.h
@@ -18,11 +18,20 @@ extern "C" {
 #endif
     #define USB_DMX_API_CALLING_CONVENTION        __stdcall
     #define USB_DMX_CALLBACK_CALLING_CONVENTION   __stdcall
+    // compatibility with legacy callback calling convention
+    // The macro USB_DMX_CALLBACK has been renamed to USB_DMX_CALLBACK_CALLING_CONVENTION
+    // in order to make clear that it's only the calling convention not possibly any other
+    // e.g. __declspec attribute. But that might break backwards compatibility of existing
+    // projects. So the old macro is here for legacy reasons. It should be marked as
+    // deprecated in future releases and finally be removed.
+    #define USB_DMX_CALLBACK USB_DMX_CALLBACK_CALLING_CONVENTION
 #else
     // not windows, remove all the dll magic
     #define USB_DMX_DLL
     #define USB_DMX_API_CALLING_CONVENTION
     #define USB_DMX_CALLBACK_CALLING_CONVENTION
+    // compatibility with legacy callback calling convention, see above comment
+    #define USB_DMX_CALLBACK
 #endif
 
 

--- a/usbdmx.h
+++ b/usbdmx.h
@@ -8,7 +8,7 @@ extern "C" {
 #include <stdint.h>
 
 #define DWORD uint32_t
-#ifdef WIN32
+#ifdef _WIN32
     #define USB_DMX_DLL __declspec(dllexport) __stdcall
     #define USB_DMX_CALLBACK __stdcall
 #else

--- a/usbdmx.h
+++ b/usbdmx.h
@@ -8,12 +8,21 @@ extern "C" {
 #include <stdint.h>
 
 #define DWORD uint32_t
-#ifdef _WIN32
-    #define USB_DMX_DLL __declspec(dllexport) __stdcall
-    #define USB_DMX_CALLBACK __stdcall
+#ifdef _WIN32 // holds true for win32 and win64
+#ifdef USB_DMX_IMPLEMENTATION
+    // compile the usbdmx implementation -> export the dll functions
+    #define USB_DMX_DLL __declspec(dllexport)
 #else
+    // use the usbdmx header in a client -> import the dll functions
+    #define USB_DMX_DLL __declspec(dllimport)
+#endif
+    #define USB_DMX_API_CALLING_CONVENTION        __stdcall
+    #define USB_DMX_CALLBACK_CALLING_CONVENTION   __stdcall
+#else
+    // not windows, remove all the dll magic
     #define USB_DMX_DLL
-    #define USB_DMX_CALLBACK
+    #define USB_DMX_API_CALLING_CONVENTION
+    #define USB_DMX_CALLBACK_CALLING_CONVENTION
 #endif
 
 
@@ -21,22 +30,22 @@ extern "C" {
 typedef unsigned char TDMXArray[512];
 typedef char TSERIAL[16];
 typedef TSERIAL TSERIALLIST[32];
-typedef void USB_DMX_CALLBACK (THOSTDEVICECHANGEPROC) (void);
-typedef void USB_DMX_CALLBACK (THOSTINPUTCHANGEPROCBLOCK) (unsigned char blocknumber);
+typedef void (USB_DMX_CALLBACK_CALLING_CONVENTION THOSTDEVICECHANGEPROC) (void);
+typedef void (USB_DMX_CALLBACK_CALLING_CONVENTION THOSTINPUTCHANGEPROCBLOCK) (unsigned char blocknumber);
 
 
 // define library functions
-USB_DMX_DLL void GetAllConnectedInterfaces(TSERIALLIST* SerialList);
-USB_DMX_DLL void GetAllOpenedInterfaces(TSERIALLIST* SerialList);
-USB_DMX_DLL DWORD OpenLink(TSERIAL Serial, TDMXArray *DMXOutArray, TDMXArray *DMXInArray);
-USB_DMX_DLL DWORD CloseLink (TSERIAL Serial);
-USB_DMX_DLL DWORD CloseAllLinks (void);
-USB_DMX_DLL DWORD RegisterInterfaceChangeNotification (THOSTDEVICECHANGEPROC Proc);
-USB_DMX_DLL DWORD UnregisterInterfaceChangeNotification (void);
-USB_DMX_DLL DWORD RegisterInputChangeNotification (THOSTDEVICECHANGEPROC Proc);
-USB_DMX_DLL DWORD UnregisterInputChangeNotification (void);
+USB_DMX_DLL void USB_DMX_API_CALLING_CONVENTION GetAllConnectedInterfaces(TSERIALLIST* SerialList);
+USB_DMX_DLL void USB_DMX_API_CALLING_CONVENTION GetAllOpenedInterfaces(TSERIALLIST* SerialList);
+USB_DMX_DLL DWORD USB_DMX_API_CALLING_CONVENTION OpenLink(TSERIAL Serial, TDMXArray *DMXOutArray, TDMXArray *DMXInArray);
+USB_DMX_DLL DWORD USB_DMX_API_CALLING_CONVENTION CloseLink (TSERIAL Serial);
+USB_DMX_DLL DWORD USB_DMX_API_CALLING_CONVENTION CloseAllLinks (void);
+USB_DMX_DLL DWORD USB_DMX_API_CALLING_CONVENTION RegisterInterfaceChangeNotification (THOSTDEVICECHANGEPROC Proc);
+USB_DMX_DLL DWORD USB_DMX_API_CALLING_CONVENTION UnregisterInterfaceChangeNotification (void);
+USB_DMX_DLL DWORD USB_DMX_API_CALLING_CONVENTION RegisterInputChangeNotification (THOSTDEVICECHANGEPROC Proc);
+USB_DMX_DLL DWORD USB_DMX_API_CALLING_CONVENTION UnregisterInputChangeNotification (void);
 
-USB_DMX_DLL DWORD SetInterfaceMode (TSERIAL Serial, unsigned char Mode);
+USB_DMX_DLL DWORD USB_DMX_API_CALLING_CONVENTION SetInterfaceMode (TSERIAL Serial, unsigned char Mode);
   // Modes:
   // 0: Do nothing - Standby
   // 1: DMX In -> DMX Out
@@ -47,18 +56,18 @@ USB_DMX_DLL DWORD SetInterfaceMode (TSERIAL Serial, unsigned char Mode);
   // 6: PC Out -> DMX Out & DMX In -> PC In
   // 7: DMX In + PC Out -> DMX Out & DMX In -> PC In
 
-USB_DMX_DLL DWORD GetDeviceVersion(TSERIAL Serial);
-USB_DMX_DLL DWORD SetInterfaceAdvTxConfig(
+USB_DMX_DLL DWORD USB_DMX_API_CALLING_CONVENTION GetDeviceVersion(TSERIAL Serial);
+USB_DMX_DLL DWORD USB_DMX_API_CALLING_CONVENTION SetInterfaceAdvTxConfig(
     TSERIAL Serial, unsigned char Control, uint16_t Breaktime, uint16_t Marktime,
     uint16_t Interbytetime, uint16_t Interframetime, uint16_t Channelcount, uint16_t Startbyte
 );
-USB_DMX_DLL DWORD StoreInterfaceAdvTxConfig(TSERIAL Serial);
-USB_DMX_DLL DWORD RegisterInputChangeBlockNotification(THOSTINPUTCHANGEPROCBLOCK Proc);
-USB_DMX_DLL DWORD UnregisterInputChangeBlockNotification(void);
+USB_DMX_DLL DWORD USB_DMX_API_CALLING_CONVENTION StoreInterfaceAdvTxConfig(TSERIAL Serial);
+USB_DMX_DLL DWORD USB_DMX_API_CALLING_CONVENTION RegisterInputChangeBlockNotification(THOSTINPUTCHANGEPROCBLOCK Proc);
+USB_DMX_DLL DWORD USB_DMX_API_CALLING_CONVENTION UnregisterInputChangeBlockNotification(void);
 
 /// And the Functions from usbdmxsi.USB_DMX_DLL also
 
-USB_DMX_DLL DWORD OpenInterface(TDMXArray * DMXOutArray, TDMXArray * DMXInArray, unsigned char Mode);
+USB_DMX_DLL DWORD USB_DMX_API_CALLING_CONVENTION OpenInterface(TDMXArray * DMXOutArray, TDMXArray * DMXInArray, unsigned char Mode);
   // Modes:
   // 0: Do nothing - Standby
   // 1: DMX In -> DMX Out
@@ -69,7 +78,7 @@ USB_DMX_DLL DWORD OpenInterface(TDMXArray * DMXOutArray, TDMXArray * DMXInArray,
   // 6: PC Out -> DMX Out & DMX In -> PC In
   // 7: DMX In + PC Out -> DMX Out & DMX In -> PC In
 
-USB_DMX_DLL DWORD CloseInterface(void);
+USB_DMX_DLL DWORD USB_DMX_API_CALLING_CONVENTION CloseInterface(void);
 
 
 #ifdef __cplusplus

--- a/usbdmx.h
+++ b/usbdmx.h
@@ -1,3 +1,6 @@
+#ifndef USBDMX_API_H
+#define USBDMX_API_H
+
 #ifdef __cplusplus
 extern "C" { 
 #endif
@@ -73,3 +76,4 @@ USB_DMX_DLL DWORD CloseInterface(void);
 }
 #endif
 
+#endif // USBDMX_API_H

--- a/usbdmx.vcxproj
+++ b/usbdmx.vcxproj
@@ -1,0 +1,178 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project DefaultTargets="Build" ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <ItemGroup Label="ProjectConfigurations">
+    <ProjectConfiguration Include="Debug|Win32">
+      <Configuration>Debug</Configuration>
+      <Platform>Win32</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Release|Win32">
+      <Configuration>Release</Configuration>
+      <Platform>Win32</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Debug|x64">
+      <Configuration>Debug</Configuration>
+      <Platform>x64</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Release|x64">
+      <Configuration>Release</Configuration>
+      <Platform>x64</Platform>
+    </ProjectConfiguration>
+  </ItemGroup>
+  <PropertyGroup Label="Globals">
+    <VCProjectVersion>15.0</VCProjectVersion>
+    <ProjectGuid>{84DF903F-178F-4420-9C7B-01B5A1577B01}</ProjectGuid>
+    <Keyword>Win32Proj</Keyword>
+    <RootNamespace>usbdmx</RootNamespace>
+    <WindowsTargetPlatformVersion>10.0.16299.0</WindowsTargetPlatformVersion>
+  </PropertyGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">
+    <ConfigurationType>DynamicLibrary</ConfigurationType>
+    <UseDebugLibraries>true</UseDebugLibraries>
+    <PlatformToolset>v141</PlatformToolset>
+    <CharacterSet>Unicode</CharacterSet>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="Configuration">
+    <ConfigurationType>DynamicLibrary</ConfigurationType>
+    <UseDebugLibraries>false</UseDebugLibraries>
+    <PlatformToolset>v141</PlatformToolset>
+    <WholeProgramOptimization>true</WholeProgramOptimization>
+    <CharacterSet>Unicode</CharacterSet>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">
+    <ConfigurationType>DynamicLibrary</ConfigurationType>
+    <UseDebugLibraries>true</UseDebugLibraries>
+    <PlatformToolset>v141</PlatformToolset>
+    <CharacterSet>Unicode</CharacterSet>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="Configuration">
+    <ConfigurationType>DynamicLibrary</ConfigurationType>
+    <UseDebugLibraries>false</UseDebugLibraries>
+    <PlatformToolset>v141</PlatformToolset>
+    <WholeProgramOptimization>true</WholeProgramOptimization>
+    <CharacterSet>Unicode</CharacterSet>
+  </PropertyGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
+  <ImportGroup Label="ExtensionSettings">
+  </ImportGroup>
+  <ImportGroup Label="Shared">
+  </ImportGroup>
+  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <PropertyGroup Label="UserMacros" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
+    <LinkIncremental>true</LinkIncremental>
+    <OutDir>$(SolutionDir)bin\$(Platform)\$(Configuration)\</OutDir>
+    <IntDir>tmp\$(Platform)\$(Configuration)\</IntDir>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
+    <LinkIncremental>true</LinkIncremental>
+    <OutDir>$(SolutionDir)bin\$(Platform)\$(Configuration)\</OutDir>
+    <IntDir>tmp\$(Platform)\$(Configuration)\</IntDir>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
+    <LinkIncremental>false</LinkIncremental>
+    <OutDir>$(SolutionDir)bin\$(Platform)\$(Configuration)\</OutDir>
+    <IntDir>tmp\$(Platform)\$(Configuration)\</IntDir>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
+    <LinkIncremental>false</LinkIncremental>
+    <OutDir>$(SolutionDir)bin\$(Platform)\$(Configuration)\</OutDir>
+    <IntDir>tmp\$(Platform)\$(Configuration)\</IntDir>
+  </PropertyGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
+    <ClCompile>
+      <WarningLevel>Level3</WarningLevel>
+      <Optimization>Disabled</Optimization>
+      <SDLCheck>true</SDLCheck>
+      <PreprocessorDefinitions>_DEBUG;USBDMX_EXPORTS;_WINDOWS;_USRDLL;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <ConformanceMode>true</ConformanceMode>
+      <AdditionalIncludeDirectories>windows</AdditionalIncludeDirectories>
+    </ClCompile>
+    <Link>
+      <SubSystem>Windows</SubSystem>
+      <GenerateDebugInformation>true</GenerateDebugInformation>
+      <AdditionalDependencies>setupapi.lib;%(AdditionalDependencies)</AdditionalDependencies>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
+    <ClCompile>
+      <WarningLevel>Level3</WarningLevel>
+      <Optimization>Disabled</Optimization>
+      <SDLCheck>true</SDLCheck>
+      <PreprocessorDefinitions>WIN32;_DEBUG;USBDMX_EXPORTS;_WINDOWS;_USRDLL;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <ConformanceMode>true</ConformanceMode>
+      <AdditionalIncludeDirectories>windows</AdditionalIncludeDirectories>
+    </ClCompile>
+    <Link>
+      <SubSystem>Windows</SubSystem>
+      <GenerateDebugInformation>true</GenerateDebugInformation>
+      <AdditionalDependencies>setupapi.lib;%(AdditionalDependencies)</AdditionalDependencies>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
+    <ClCompile>
+      <WarningLevel>Level3</WarningLevel>
+      <Optimization>MaxSpeed</Optimization>
+      <FunctionLevelLinking>true</FunctionLevelLinking>
+      <IntrinsicFunctions>true</IntrinsicFunctions>
+      <SDLCheck>true</SDLCheck>
+      <PreprocessorDefinitions>WIN32;NDEBUG;USBDMX_EXPORTS;_WINDOWS;_USRDLL;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <ConformanceMode>true</ConformanceMode>
+      <AdditionalIncludeDirectories>windows</AdditionalIncludeDirectories>
+    </ClCompile>
+    <Link>
+      <SubSystem>Windows</SubSystem>
+      <EnableCOMDATFolding>true</EnableCOMDATFolding>
+      <OptimizeReferences>true</OptimizeReferences>
+      <GenerateDebugInformation>true</GenerateDebugInformation>
+      <AdditionalDependencies>setupapi.lib;%(AdditionalDependencies)</AdditionalDependencies>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
+    <ClCompile>
+      <WarningLevel>Level3</WarningLevel>
+      <Optimization>MaxSpeed</Optimization>
+      <FunctionLevelLinking>true</FunctionLevelLinking>
+      <IntrinsicFunctions>true</IntrinsicFunctions>
+      <SDLCheck>true</SDLCheck>
+      <PreprocessorDefinitions>NDEBUG;USBDMX_EXPORTS;_WINDOWS;_USRDLL;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <ConformanceMode>true</ConformanceMode>
+      <AdditionalIncludeDirectories>windows</AdditionalIncludeDirectories>
+    </ClCompile>
+    <Link>
+      <SubSystem>Windows</SubSystem>
+      <EnableCOMDATFolding>true</EnableCOMDATFolding>
+      <OptimizeReferences>true</OptimizeReferences>
+      <GenerateDebugInformation>true</GenerateDebugInformation>
+      <AdditionalDependencies>setupapi.lib;%(AdditionalDependencies)</AdditionalDependencies>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemGroup>
+    <ClCompile Include="usbdmx.c" />
+    <ClCompile Include="windows\dllmain.cpp" />
+    <ClCompile Include="windows\hid.c" />
+    <ClCompile Include="windows\pthread.c" />
+    <ClCompile Include="windows\usleep.cpp" />
+  </ItemGroup>
+  <ItemGroup>
+    <ClInclude Include="hidapi.h" />
+    <ClInclude Include="usbdmx.h" />
+    <ClInclude Include="windows\pthread.h" />
+    <ClInclude Include="windows\targetver.h" />
+    <ClInclude Include="windows\usleep.h" />
+  </ItemGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
+  <ImportGroup Label="ExtensionTargets">
+  </ImportGroup>
+</Project>

--- a/usbdmx.vcxproj.filters
+++ b/usbdmx.vcxproj.filters
@@ -1,0 +1,36 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <ItemGroup>
+    <Filter Include="windows">
+      <UniqueIdentifier>{edd5eac2-feaa-461f-9fe8-c1257175ed3d}</UniqueIdentifier>
+    </Filter>
+  </ItemGroup>
+  <ItemGroup>
+    <ClCompile Include="windows\hid.c">
+      <Filter>windows</Filter>
+    </ClCompile>
+    <ClCompile Include="usbdmx.c" />
+    <ClCompile Include="windows\pthread.c">
+      <Filter>windows</Filter>
+    </ClCompile>
+    <ClCompile Include="windows\dllmain.cpp">
+      <Filter>windows</Filter>
+    </ClCompile>
+    <ClCompile Include="windows\usleep.cpp">
+      <Filter>windows</Filter>
+    </ClCompile>
+  </ItemGroup>
+  <ItemGroup>
+    <ClInclude Include="hidapi.h" />
+    <ClInclude Include="usbdmx.h" />
+    <ClInclude Include="windows\pthread.h">
+      <Filter>windows</Filter>
+    </ClInclude>
+    <ClInclude Include="windows\targetver.h">
+      <Filter>windows</Filter>
+    </ClInclude>
+    <ClInclude Include="windows\usleep.h">
+      <Filter>windows</Filter>
+    </ClInclude>
+  </ItemGroup>
+</Project>

--- a/usbdmx_example.cpp
+++ b/usbdmx_example.cpp
@@ -6,15 +6,15 @@ extern "C" {
 #include <string.h>
 #include <stdlib.h>
 
-void USB_DMX_CALLBACK InterfaceChange(void) {
+void USB_DMX_CALLBACK_CALLING_CONVENTION InterfaceChange(void) {
     printf("Interface cnonfiguration has changed\n");
 }
 
-void USB_DMX_CALLBACK InputChange(void) {
+void USB_DMX_CALLBACK_CALLING_CONVENTION InputChange(void) {
     printf("Input has changed\n");
 }
 
-void USB_DMX_CALLBACK InputChangeBlock(unsigned char block_number) {
+void USB_DMX_CALLBACK_CALLING_CONVENTION InputChangeBlock(unsigned char block_number) {
     // printf("Block %d changed\n", block_number);
 }
 

--- a/windows/dllmain.cpp
+++ b/windows/dllmain.cpp
@@ -1,0 +1,20 @@
+// dllmain.cpp : Defines the entry point for the DLL application.
+#include "targetver.h"
+#define WIN32_LEAN_AND_MEAN // Exclude rarely-used stuff from Windows headers
+#include <windows.h>
+
+BOOL APIENTRY DllMain( HMODULE hModule,
+                       DWORD  ul_reason_for_call,
+                       LPVOID lpReserved
+                     )
+{
+    switch (ul_reason_for_call)
+    {
+    case DLL_PROCESS_ATTACH:
+    case DLL_THREAD_ATTACH:
+    case DLL_THREAD_DETACH:
+    case DLL_PROCESS_DETACH:
+        break;
+    }
+    return TRUE;
+}

--- a/windows/hid.c
+++ b/windows/hid.c
@@ -20,6 +20,10 @@
         http://github.com/signal11/hidapi .
 ********************************************************/
 
+#ifdef _MSC_VER
+#include "targetver.h"
+#define WIN32_LEAN_AND_MEAN // Exclude rarely-used stuff from Windows headers
+#endif
 #include <windows.h>
 
 #ifndef _NTDEF_

--- a/windows/pthread.c
+++ b/windows/pthread.c
@@ -1,7 +1,10 @@
+#ifdef _MSC_VER
+#include "targetver.h"
+#define WIN32_LEAN_AND_MEAN // Exclude rarely-used stuff from Windows headers
+#endif
 #include <windows.h>
 #include "pthread.h"
 
 void pthread_create(pthread_t * thread_pointer, void * null, void * (*function) (void*), void * pointer) {
     CreateThread(NULL, 0, (LPTHREAD_START_ROUTINE) function, pointer, 0, NULL);
 }
-

--- a/windows/pthread.h
+++ b/windows/pthread.h
@@ -1,4 +1,15 @@
+#ifndef USBDMX_PTHREAD_H
+#define USBDMX_PTHREAD_H
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 typedef void* pthread_t;
 void pthread_create(pthread_t * thread_pointer, void * null, void * (*function) (void*), void * pointer);
 
+#ifdef __cplusplus
+}
+#endif
 
+#endif // USBDMX_PTHREAD_H

--- a/windows/targetver.h
+++ b/windows/targetver.h
@@ -1,0 +1,8 @@
+#pragma once
+
+// Including SDKDDKVer.h defines the highest available Windows platform.
+
+// If you wish to build your application for a previous Windows platform, include WinSDKVer.h and
+// set the _WIN32_WINNT macro to the platform you wish to support before including SDKDDKVer.h.
+
+#include <SDKDDKVer.h>

--- a/windows/usleep.cpp
+++ b/windows/usleep.cpp
@@ -1,0 +1,8 @@
+#include "usleep.h"
+#include <chrono>
+#include <thread>
+
+int usleep(useconds_t usec) {
+    std::this_thread::sleep_for(std::chrono::microseconds(usec));
+    return 0;
+}

--- a/windows/usleep.h
+++ b/windows/usleep.h
@@ -1,4 +1,5 @@
 #ifndef USBDMX_USLEEP_H
+#define USBDMX_USLEEP_H
 
 #ifdef __cplusplus
 extern "C" {

--- a/windows/usleep.h
+++ b/windows/usleep.h
@@ -1,0 +1,14 @@
+#ifndef USBDMX_USLEEP_H
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+typedef unsigned int useconds_t;
+int usleep(useconds_t usec);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif // USBDMX_USLEEP_H


### PR DESCRIPTION
Compiler macros and MSVC specific settings have been added to correctly compile under MSVC in VS 2017. The other pull requests should go together with this one, to compile without warnings.